### PR TITLE
allow single argument for `union!!` and `setdiff!!`, add `intersect!!` and `symdiff!!`

### DIFF
--- a/src/BangBang.jl
+++ b/src/BangBang.jl
@@ -14,6 +14,7 @@ export @!,
        deleteat!!,
        empty!!,
        finish!,
+       intersect!!,
        lmul!!,
        materialize!!,
        merge!!,
@@ -31,6 +32,7 @@ export @!,
        setproperty!!,
        singletonof,
        splice!!,
+       symdiff!!,
        union!!,
        unique!!
 
@@ -58,6 +60,8 @@ include("utils.jl")
 function implements end
 function push!! end
 function unique!! end
+function union!! end
+function symdiff!! end
 
 include("NoBang/NoBang.jl")
 using .NoBang: Empty, SingletonVector, singletonof

--- a/src/NoBang/NoBang.jl
+++ b/src/NoBang/NoBang.jl
@@ -7,7 +7,7 @@ using Base: ImmutableDict
 using Requires
 using ConstructionBase: constructorof, setproperties
 
-using ..BangBang: push!!, unique!!, implements
+using ..BangBang: push!!, unique!!, union!!, symdiff!!, implements
 
 include("singletoncontainers.jl")
 include("base.jl")

--- a/src/NoBang/base.jl
+++ b/src/NoBang/base.jl
@@ -151,6 +151,10 @@ setproperty(value, name, x) = setproperties(value, NamedTuple{(name,)}((x,)))
 
 materialize(::Any, x) = Broadcast.materialize(x)
 
-@inline _union(a, b) = union(a, b)
+@inline _union(args...) = union(args...)
 
-@inline _setdiff(a, b) = setdiff(a, b)
+@inline _intersect(args...) = intersect(args...)
+
+@inline _setdiff(args...) = setdiff(args...)
+
+@inline _symdiff(args...) = symdiff(args...)

--- a/src/NoBang/emptycontainers.jl
+++ b/src/NoBang/emptycontainers.jl
@@ -82,7 +82,7 @@ _intersect(x::Empty, ys...) = x
 
 _setdiff(x::Empty, ys...) = x
 
-_symdiff(::Empty{T}, x, ys) where {T} = symdiff!!(unique!!(T(x)), ys...)
+_symdiff(::Empty{T}, x, ys...) where {T} = symdiff!!(unique!!(T(x)), ys...)
 _symdiff(e::Empty, ::Empty...) = e
 
 _setindex(::Empty{T}, v, k) where {T <: AbstractDict} = T(SingletonDict(k, v))

--- a/src/NoBang/emptycontainers.jl
+++ b/src/NoBang/emptycontainers.jl
@@ -75,10 +75,15 @@ append(e::Empty, ::Empty) = e
 _empty(x::Empty) = x
 resize(::Empty{T}, n::Integer) where {T <: AbstractVector} = similar(T, (n,))
 
-_union(::Empty{T}, x) where {T} = unique!!(T(x))
-_union(e::Empty, ::Empty) = e
+_union(::Empty{T}, x, ys...) where {T} = union!!(unique!!(T(x)), ys...)
+_union(e::Empty, ::Empty...) = e
 
-_setdiff(x::Empty, _) = x
+_intersect(x::Empty, ys...) = x
+
+_setdiff(x::Empty, ys...) = x
+
+_symdiff(::Empty{T}, x, ys) where {T} = symdiff!!(unique!!(T(x)), ys...)
+_symdiff(e::Empty, ::Empty...) = e
 
 _setindex(::Empty{T}, v, k) where {T <: AbstractDict} = T(SingletonDict(k, v))
 Base.get(::Empty, _, default) = default

--- a/src/initials.jl
+++ b/src/initials.jl
@@ -84,3 +84,15 @@ InitialValues.hasinitialvalue(::Type{typeof(union!!)}) = true
 
 copyunionable(src::AbstractVector) = Base.copymutable(src)
 copyunionable(src) = Set(src)
+
+const InitIntersect!! = InitialValues.GenericInitialValue{typeof(intersect!!)}
+intersect!!(dest::InitIntersect!!, src) = copyunionable(src)
+intersect!!(dest, ::InitIntersect!!) = dest
+intersect!!(dest::InitIntersect!!, src::InitIntersect!!) = dest
+InitialValues.hasinitialvalue(::Type{typeof(intersect!!)}) = true
+
+const InitSymdiff!! = InitialValues.GenericInitialValue{typeof(symdiff!!)}
+symdiff!!(dest::InitSymdiff!!, src) = copyunionable(src)
+symdiff!!(dest, ::InitSymdiff!!) = dest
+symdiff!!(dest::InitSymdiff!!, src::InitSymdiff!!) = dest
+InitialValues.hasinitialvalue(::Type{typeof(symdiff!!)}) = true

--- a/test/test_intersect.jl
+++ b/test/test_intersect.jl
@@ -1,0 +1,25 @@
+module TestIntersect
+
+include("preamble.jl")
+# using MicroCollections: SingletonSet
+
+@testset begin
+    @test_returns_first intersect!!([0]) == [0]
+    @test_returns_first intersect!!(Set([0])) == Set([0])
+    @test_returns_first intersect!!([0], [1]) == []
+    @test_returns_first intersect!!([0], (1,)) == []
+    @test_returns_first intersect!!([0, 1, 2], (0, 1), [1, 2]) == [1]
+    @test_returns_first intersect!!(Set([0]), [0]) == Set([0])
+    @test_returns_first intersect!!(Set([0]), (0,)) == Set([0])
+    @test_returns_first intersect!!(Set([0, 1, 2]), Set([0,1]), [1, 2]) == Set([1])
+    @test intersect!!(Empty(Set)) === Empty(Set)
+    @test intersect!!(Empty(Vector), Empty(Set)) === Empty(Vector)
+    @test intersect!!(Empty(Vector), [0]) === Empty(Vector)
+    @test intersect!!(Empty(Set{Int}), [0]) === Empty(Set{Int})
+    #=
+    @test intersect!!(SingletonSet((0,)), [0]) ==ₜ Set([0])
+    @test intersect!!(SingletonSet((0,)), [1]) ==ₜ Set{Int}()
+    =#
+end
+
+end  # module

--- a/test/test_setdiff.jl
+++ b/test/test_setdiff.jl
@@ -4,13 +4,16 @@ include("preamble.jl")
 # using MicroCollections: SingletonSet
 
 @testset begin
+    @test_returns_first setdiff!!([0]) == [0]
+    @test_returns_first setdiff!!(Set([0])) == Set([0])
     @test_returns_first setdiff!!([0], [0]) == []
     @test_returns_first setdiff!!([0], (0,)) == []
     @test_returns_first setdiff!!([0, 1, 2], (0,), [1]) == [2]
     @test_returns_first setdiff!!(Set([0]), [0]) == Set()
     @test_returns_first setdiff!!(Set([0]), (0,)) == Set()
     @test_returns_first setdiff!!(Set([0, 1, 2]), Set([0]), [1]) == Set([2])
-    @test setdiff!!(Empty(Vector), []) === Empty(Vector)
+    @test setdiff!!(Empty(Set)) === Empty(Set)
+    @test setdiff!!(Empty(Vector), Empty(Set)) === Empty(Vector)
     @test setdiff!!(Empty(Set{Int}), []) === Empty(Set{Int})
     #=
     @test setdiff!!(SingletonSet((0,)), [0]) ==ₜ Set{Int}()

--- a/test/test_symdiff.jl
+++ b/test/test_symdiff.jl
@@ -1,0 +1,24 @@
+module TestSymdiff
+
+include("preamble.jl")
+# using MicroCollections: SingletonSet
+
+@testset begin
+    @test_returns_first symdiff!!([0]) == [0]
+    @test_returns_first symdiff!!(Set([0])) == Set([0])
+    @test_returns_first symdiff!!([0], [0]) == []
+    @test_returns_first symdiff!!([0], (0,)) == []
+    @test_returns_first symdiff!!([0, 1, 2], (0, 1), [1, 3]) == [1, 2, 3]
+    @test_returns_first symdiff!!(Set([0]), [0]) == Set()
+    @test_returns_first symdiff!!(Set([0]), (1,)) == Set([0, 1])
+    @test_returns_first symdiff!!(Set([0, 1, 2]), Set([0, 1]), [1]) == Set([1, 2])
+    @test symdiff!!(Empty(Set)) === Empty(Set)
+    @test symdiff!!(Empty(Vector), Empty(Vector)) === Empty(Vector)
+    @test symdiff!!(Empty(Set{Int}), Empty(Vector)) === Empty(Set{Int})
+    #=
+    @test symdiff!!(SingletonSet((0,)), [0]) ==ₜ Set{Int}()
+    @test symdiff!!(SingletonSet((0,)), [1]) ==ₜ Set([0, 1])
+    =#
+end
+
+end  # module

--- a/test/test_union.jl
+++ b/test/test_union.jl
@@ -5,6 +5,8 @@ using BangBang: SingletonVector
 using InitialValues: InitialValue, asmonoid
 
 @testset begin
+    @test_returns_first union!!([0]) == [0]
+    @test_returns_first union!!(Set([0])) == Set([0])
     @test union!!([0.0], [1.0]) ==ₜ [0.0, 1.0]
     @test union!!([0], [0.5]) ==ₜ [0.0, 0.5]
     @test union!!(Set([0.0]), [1.0]) ==ₜ Set([0.0, 1.0])
@@ -18,6 +20,7 @@ end
         @test union!!(Empty(Set), Empty(Set)) === Empty(Set)
         @test union!!(Empty(Set), Empty(Vector)) === Empty(Set)
     end
+    @test union!!(Empty(Set)) === Empty(Set)
 end
 
 @testset "mutation" begin


### PR DESCRIPTION
This PR makes the following changes:

* `union!!` and `setdiff!!` now accept a single argument, like `union`, `union!` etc.

* A mistake in the doc string for `setdiff!!` is corrected.

* New functions `intersect!!` and `symdiff!!` are added. I don't know why they were missing so far.

* All four functions pass all their arguments at once to the no-bang or single-bang version instead of using `foldl`. I see no reason not to do it. Moreover, for `symdiff!!` this preserves the order of elements whereas `foldl` would change it.

This PR does not address the issue #14.