### PR TITLE
Further specializations for `setindex!!`

### DIFF
--- a/test/test_setindex.jl
+++ b/test/test_setindex.jl
@@ -53,6 +53,10 @@ end
         xs = Vector{Vector{Float64}}(undef, 2)
         setindex!!(xs, [1.0], 1)
         @test xs[1] == [1.0]
+
+        xs = Vector(undef, 2)
+        setindex!!(xs, 1.0, 1)
+        @test xs[1] == 1.0
     end
 end
 

--- a/test/test_setindex.jl
+++ b/test/test_setindex.jl
@@ -47,6 +47,13 @@ end
         @test setindex!!([1, 2, 3], [4, 5], 1) == [[4, 5], 2, 3]
         @test setindex!!([1, 2, 3], [4, 5, 6], :, 1) == [4, 5, 6]
     end
+
+    @testset "should mutate" begin
+        # Ref: https://github.com/JuliaFolds2/BangBang.jl/issues/21
+        xs = Vector{Vector{Float64}}(undef, 2)
+        setindex!!(xs, [1.0], 1)
+        @test xs[1] == [1.0]
+    end
 end
 
 @testset "slices" begin


### PR DESCRIPTION
Ref: https://github.com/JuliaFolds2/BangBang.jl/issues/21#issuecomment-2067788205

This PR adds further specializations to `possible(::typeof(__setindex!), ...)` to improve selection of mutating version.

For example:

``` julia
xs = Vector{Vector{Float64}}(undef, 2)
setindex!!(xs, [1.0], 1)
```

is not mutating on #master but is on this branch.