### PR TITLE
Bump Julia compat to 1.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.10', 'nightly']
+        julia-version: ['1.10', '1', 'nightly']
         julia-arch: [x64, x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.6', '1.9', '1.10', 'nightly']
+        julia-version: ['1.10', 'nightly']
         julia-arch: [x64, x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 InitialValues = "22cec73e-a1b8-11e9-2c92-598750a2cf9c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -36,8 +35,7 @@ StaticArrays = "1"
 StructArrays = "0.6,0.7"
 Tables = "0.2, 1"
 TypedTables = "1"
-julia = "1.6"
-Requires = "1"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BangBang"
 uuid = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/BangBang.jl
+++ b/src/BangBang.jl
@@ -49,10 +49,6 @@ using ConstructionBase: constructorof
 using InitialValues
 using LinearAlgebra
 
-@static if !isdefined(Base, :get_extension)
-    using Requires
-end
-
 include("utils.jl")
 
 # Used in NoBang:
@@ -76,28 +72,5 @@ include("macro.jl")
 include("accessors.jl")
 
 using .AccessorsImpl: @set!!, prefermutation
-
-function __init__()
-    @static if !isdefined(Base, :get_extension)
-        @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" begin
-            include("../ext/BangBangStaticArraysExt.jl")
-        end
-        @require StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a" begin
-            include("../ext/BangBangStructArraysExt.jl")
-        end
-        @require Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c" begin
-            include("../ext/BangBangTablesExt.jl")
-        end
-        @require TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9" begin
-            include("../ext/BangBangTypedTablesExt.jl")
-        end
-        @require DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
-            include("../ext/BangBangDataFramesExt.jl")
-        end
-        @require ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4" begin
-            include("../ext/BangBangChainRulesCoreExt.jl")
-        end
-    end
-end
 
 end # module


### PR DESCRIPTION
Since Julia 1.9 is no longer supported, presumably future versions of BangBang would not need to support it.
Removing 1.9 support allows the Requires dependency to be deleted.

Note that this PR does NOT bump the version of the package!

Closes #28 