### PR TITLE
Unify broadcasting behavior of `materialize!!`

### DIFF
--- a/src/NoBang/base.jl
+++ b/src/NoBang/base.jl
@@ -149,7 +149,8 @@ resize(xs::AbstractVector, n::Integer) = similar(xs, (n,))
 
 setproperty(value, name, x) = setproperties(value, NamedTuple{(name,)}((x,)))
 
-materialize(::Any, x) = Broadcast.materialize(x)
+materialize(dest, x) =
+    Broadcast.materialize(Broadcast.instantiate(Broadcast.broadcasted(first ∘ tuple, x, dest)))
 
 @inline _union(args...) = union(args...)
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -85,6 +85,7 @@ implements(::typeof(setproperty!), ::Type{<:NamedTuple}) = false
 
 struct Undefined end
 implements(::Mutator, ::Undefined) = false
+Base.broadcastable(x::Undefined) = Ref(x)
 
 """
     possible(f!, args...) :: Bool

--- a/test/preamble.jl
+++ b/test/preamble.jl
@@ -3,7 +3,7 @@ using Test
 using Base: ImmutableDict
 using BangBang
 using BangBang: implements
-using StaticArrays: SVector
+using StaticArrays: SVector, SizedVector
 
 """
     ==ₜ(x, y)

--- a/test/test_macro.jl
+++ b/test/test_macro.jl
@@ -33,7 +33,15 @@ end
 
     let x = [1, 2]
         y = SVector(0, 0)
-        @test (@! y .= x .* 2)::Vector{Int} == [2, 4]
+        @test (@! y .= x .* 2)::SizedVector{2, Int} == [2, 4]
+    end
+
+    let y = [0, 0]
+        @test (@! y .= 1)::Vector{Int} == [1, 1]
+    end
+
+    let y = SVector(0, 0)
+        @test (@! y .= 1) === SVector(1, 1)
     end
 end
 
@@ -63,7 +71,15 @@ end
 
     let x = [1, 2]
         y = SVector(0, 0)
-        @test (@! @. y = x * 2)::Vector{Int} == [2, 4]
+        @test (@! @. y = x * 2)::SizedVector{2, Int} == [2, 4]
+    end
+
+    let y = [0, 0]
+        @test (@! @. y = 1)::Vector{Int} == [1, 1]
+    end
+
+    let y = SVector(0, 0)
+        @test (@! @. y = 1) === SVector(1, 1)
     end
 end
 


### PR DESCRIPTION
Addresses #34 

The broadcasting behavior of `materialize!!(dest, x)` is made consistent for mutable and immutable destinations `dest`. Previously, the shape and type of immutable `dest` was not considered. This commit changes NoBang.materialize to also let the `dest` participate in the broadcast, thereby propagating information about its shape and type.

Not sure if `broadcasted(first ∘ tuple, x, dest))` is the most idiomatic way to do this, but it seems to work.

Note that this also narrows down the type of the result:
Previously, `materialize!!(::SVector, x)` would yield whatever `x` was.
Now, `materialize!!(::SVector{N,T}, ::T)` is still a `SVector{N,T}` and `materialize!!(::SVector, ::Vector)` is a `SizedVector`, i.e. information about the type and size are retained.