### PR TITLE
Fix `@!` macro for dot-updating operators

### DIFF
--- a/test/test_macro.jl
+++ b/test/test_macro.jl
@@ -43,6 +43,15 @@ end
     let y = SVector(0, 0)
         @test (@! y .= 1) === SVector(1, 1)
     end
+
+    let x = [1, 2]
+        y = SVector(0, 0)
+        @test (@! y .+= x)::SizedVector{2, Int} == [1, 2]
+    end
+
+    let y = SVector(0, 0)
+        @test (@! y .+= 1) === SVector(1, 1)
+    end
 end
 
 @testset "@." begin
@@ -80,6 +89,15 @@ end
 
     let y = SVector(0, 0)
         @test (@! @. y = 1) === SVector(1, 1)
+    end
+
+    let x = [1, 2]
+        y = SVector(0, 0)
+        @test (@! @. y += x)::SizedVector{2, Int} == [1, 2]
+    end
+
+    let y = SVector(0, 0)
+        @test (@! @. y += 1) === SVector(1, 1)
     end
 end
 


### PR DESCRIPTION
Fixes #36 

Let the macro `@!` recognize dot-updating operators such as `.+=`, `.*=`, etc. and use the BangBang method for the required broadcasting.

Extracting the operator via string comparison is admittedly a bit clumsy. Maybe there is a more generic method using a lowered representation of the expression, but my attempts with `Meta.lower` have not been successful so far.