### PR TITLE
Mark `setindex!` on SizedArray as possible

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BangBang"
 uuid = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>"]
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/ext/BangBangStaticArraysExt.jl
+++ b/ext/BangBangStaticArraysExt.jl
@@ -34,5 +34,6 @@ end
 
     BangBang.implements(::BangBang.Mutator, ::Type{<:StaticArrays.StaticArray}) = false
     BangBang.implements(::typeof(setindex!), ::Type{<:StaticArrays.MArray}) = true
+    BangBang.implements(::typeof(setindex!), ::Type{<:StaticArrays.SizedArray}) = true
     BangBang.copyappendable(src::StaticArrays.StaticVector) = src
 end


### PR DESCRIPTION
`StaticArrays.SizedArray` is mutable and has `setindex!` defined on it (method is defined [here](https://github.com/JuliaArrays/StaticArrays.jl/blob/58bf1e128317b2c1589128e724ec66f9789719f0/src/SizedArray.jl#L93)), so this PR allows BangBang to make use of it:

```julia
julia> using BangBang, StaticArrays

julia> v = @SVector zeros(3)
3-element SVector{3, Float64} with indices SOneTo(3):
 0.0
 0.0
 0.0

julia> v2 = similar(v, Real)
3-element SizedVector{3, Real, Vector{Real}} with indices SOneTo(3):
 #undef
 #undef
 #undef

julia> setindex!(v2, 1.0, 1)
3-element SizedVector{3, Real, Vector{Real}} with indices SOneTo(3):
   1.0
 #undef
 #undef

julia> # With this PR
       BangBang.setindex!!(v2, 1.0, 1)
3-element SizedVector{3, Real, Vector{Real}} with indices SOneTo(3):
   1.0
 #undef
 #undef
```

Right now `BangBang.setindex!!` errors as it tries to go through an immutable path, which hits https://github.com/JuliaArrays/StaticArrays.jl/issues/1330:

```julia
julia> v3 = similar(v, Real)
3-element SizedVector{3, Real, Vector{Real}} with indices SOneTo(3):
 #undef
 #undef
 #undef

julia> BangBang.setindex!!(v3, 1.0, 1)
ERROR: UndefRefError: access to undefined reference
Stacktrace:
 [1] getindex
   @ ./essentials.jl:917 [inlined]
 [2] getindex
   @ ~/.julia/packages/StaticArrays/IZgIP/src/SizedArray.jl:92 [inlined]
 [3] macro expansion
   @ ~/.julia/packages/StaticArrays/IZgIP/src/deque.jl:193 [inlined]
 [4] _setindex
   @ ~/.julia/packages/StaticArrays/IZgIP/src/deque.jl:186 [inlined]
 [5] setindex
   @ ~/.julia/packages/StaticArrays/IZgIP/src/deque.jl:185 [inlined]
 [6] _setindex
   @ ~/ppl/BangBang.jl/ext/BangBangStaticArraysExt.jl:27 [inlined]
 [7] may
   @ ~/ppl/BangBang.jl/src/core.jl:11 [inlined]
 [8] setindex!!(xs::SizedVector{3, Real, Vector{Real}}, v::Float64, I::Int64)
   @ BangBang ~/ppl/BangBang.jl/src/base.jl:478
 [9] top-level scope
   @ REPL[15]:1
```